### PR TITLE
Cleaning up required providers in modules. See battelle-cube/cube-pla…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.80.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.6.0"
+    }
+  }
+}
+
 ########################################
 # Inputs
 ########################################


### PR DESCRIPTION
…tform#33

This looks to eliminate the 'Warning: Provider azurerm is undefined' in terraform applies

This could maybe be cleaned up further or made more descriptive but this only requires a change to the provider block while calling the terraform-cube-core module in the workload.

I also included the provider version that currently gets used, maybe we can/should start keeping that in check too? Made an assumption with the version constraint, we can tweak that.

Old:
![image](https://user-images.githubusercontent.com/87024395/146754687-c379ee97-9e77-49bf-b884-15ad9aa37419.png)

New:
![image](https://user-images.githubusercontent.com/87024395/146754719-67836582-c149-4ce5-878f-3bdee3a9ad18.png)
